### PR TITLE
Update homepage for current role and reframe old projects

### DIFF
--- a/src/pages/adventures/index.astro
+++ b/src/pages/adventures/index.astro
@@ -17,7 +17,7 @@ const items = entries.map((entry) => ({
 
 <ArchiveLayout
   title="Adventures"
-  description="You only get one life, live it."
+  description="Notes and photos from time spent outside."
   basePath="/adventures"
   items={items}
 />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
     <div class="prose">
       <p>
-        I'm a backend engineer working on AI insights tooling at Spotify.
+        I'm a backend engineer working on AI insights tooling at <strong>Spotify</strong>.
       </p>
       <p>
         Outside of work I spend time backpacking, mountain biking, kayaking, and camping. A few
@@ -22,9 +22,9 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         archive from that period.
       </p>
     </div>
-  </section>
 
-  <hr class="divider container" />
+    <div class="rule" aria-hidden="true"></div>
+  </section>
 
   <section class="section container elsewhere">
     <p class="eyebrow">Elsewhere</p>
@@ -57,6 +57,18 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     font-size: 17px;
   }
 
+  .prose strong {
+    font-weight: 600;
+    color: var(--color-accent);
+  }
+
+  .rule {
+    width: 56px;
+    height: 3px;
+    background: var(--color-accent);
+    margin-top: 32px;
+  }
+
   .elsewhere {
     padding-block-start: calc(var(--rhythm) / 2);
   }
@@ -64,7 +76,21 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   .link-row {
     display: flex;
     flex-wrap: wrap;
-    gap: 12px;
+    gap: 14px;
     margin-top: 16px;
+    padding: 28px;
+    background: var(--color-bg-alt);
+    border-radius: 14px;
+  }
+
+  .link-row .btn {
+    background: var(--color-bg);
+    transition: transform 0.15s ease, box-shadow 0.15s ease, color 0.15s ease,
+      border-color 0.15s ease;
+  }
+
+  .link-row .btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px rgba(178, 92, 57, 0.25);
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,14 +12,14 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         I'm a backend engineer working on AI insights tooling at Spotify.
       </p>
       <p>
-        I hold a Master of Science in Computer Science from Clemson University, with a focus on
-        informatics and scientific computation. The <a href="/projects/">projects</a> section is an
-        archive from that period.
-      </p>
-      <p>
         Outside of work I spend time backpacking, mountain biking, kayaking, and camping. A few
         of those trips are written up in <a href="/adventures/">adventures</a>, with more to come.
         I also brew beer and build small apps in my spare time.
+      </p>
+      <p>
+        I hold a Master of Science in Computer Science from Clemson University, with a focus on
+        informatics and scientific computation. The <a href="/projects/">projects</a> section is an
+        archive from that period.
       </p>
     </div>
   </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,11 +19,28 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       <p>
         Outside of work I spend time backpacking, mountain biking, kayaking, and camping. A few
         of those trips are written up in <a href="/adventures/">adventures</a>, with more to come.
+        I also brew beer and build small apps in my spare time.
       </p>
-      <p>
-        I also put time into two ongoing hobbies: homebrewing at <a href="https://notomorrowbrewing.com" target="_blank" rel="noopener noreferrer">Not Tomorrow Brewing</a>,
-        and building <a href="https://tour-de-friends.fly.dev/" target="_blank" rel="noopener noreferrer">Tour de Friends</a>, an app for tracking group rides with friends.
-      </p>
+    </div>
+  </section>
+
+  <hr class="divider container" />
+
+  <section class="section container elsewhere">
+    <p class="eyebrow">Elsewhere</p>
+    <div class="link-row">
+      <a class="btn" href="https://strava.app.link/R5BN3emEM4b" target="_blank" rel="noopener noreferrer"
+        >Strava <span aria-hidden="true">↗</span></a
+      >
+      <a class="btn" href="https://notomorrowbrewing.com" target="_blank" rel="noopener noreferrer"
+        >Not Tomorrow Brewing <span aria-hidden="true">↗</span></a
+      >
+      <a class="btn" href="https://tour-de-friends.fly.dev/" target="_blank" rel="noopener noreferrer"
+        >Tour de Friends <span aria-hidden="true">↗</span></a
+      >
+      <a class="btn" href="https://github.com/ltmorro" target="_blank" rel="noopener noreferrer"
+        >GitHub <span aria-hidden="true">↗</span></a
+      >
     </div>
   </section>
 </BaseLayout>
@@ -35,5 +52,16 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
   .prose p {
     font-size: 17px;
+  }
+
+  .elsewhere {
+    padding-block-start: calc(var(--rhythm) / 2);
+  }
+
+  .link-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 16px;
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,6 +29,9 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <section class="section container elsewhere">
     <p class="eyebrow">Elsewhere</p>
     <div class="link-row">
+      <a class="btn" href="https://www.linkedin.com/in/luke-morrow" target="_blank" rel="noopener noreferrer"
+        >LinkedIn <span aria-hidden="true">↗</span></a
+      >
       <a class="btn" href="https://strava.app.link/R5BN3emEM4b" target="_blank" rel="noopener noreferrer"
         >Strava <span aria-hidden="true">↗</span></a
       >

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,18 +9,21 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
     <div class="prose">
       <p>
-        I'm currently working as a Data Scientist at a Marketing Agency in Austin, TX.
+        I'm a backend engineer working on AI insights tooling at Spotify.
       </p>
       <p>
         I graduated with a Master of Science in Computer Science from Clemson University in
-        2018. My area of focus is Informatics and Scientific Computation. I'm captivated by
-        data science, machine learning, artificial intelligence, and cyber security.
-        Interested in what I've done? Look <a href="/projects/">here!</a>
+        2018, focused on Informatics and Scientific Computation. The <a href="/projects/">projects</a> section
+        is an archive of what I built back in grad school — a snapshot of where I started.
       </p>
       <p>
-        When I'm not programming, you can find me exploring the great outdoors. I relish any
+        When I'm not working, you can find me exploring the great outdoors. I relish any
         activity that brings me outside including backpacking, mountain biking, kayaking, and
-        camping! Check out some of my adventures <a href="/adventures/">here!</a>
+        camping! Check out some of my adventures <a href="/adventures/">here</a> — more to come.
+      </p>
+      <p>
+        These days I put most of my spare time into two hobbies: homebrewing with <a href="https://notomorrowbrewing.com" target="_blank" rel="noopener noreferrer">Not Tomorrow Brewing</a>, and
+        building <a href="https://tour-de-friends.fly.dev/" target="_blank" rel="noopener noreferrer">Tour de Friends</a>, an app for tracking group rides with friends.
       </p>
     </div>
   </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,18 +12,17 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         I'm a backend engineer working on AI insights tooling at Spotify.
       </p>
       <p>
-        I graduated with a Master of Science in Computer Science from Clemson University in
-        2018, focused on Informatics and Scientific Computation. The <a href="/projects/">projects</a> section
-        is an archive of what I built back in grad school — a snapshot of where I started.
+        I hold a Master of Science in Computer Science from Clemson University, with a focus on
+        informatics and scientific computation. The <a href="/projects/">projects</a> section is an
+        archive from that period.
       </p>
       <p>
-        When I'm not working, you can find me exploring the great outdoors. I relish any
-        activity that brings me outside including backpacking, mountain biking, kayaking, and
-        camping! Check out some of my adventures <a href="/adventures/">here</a> — more to come.
+        Outside of work I spend time backpacking, mountain biking, kayaking, and camping. A few
+        of those trips are written up in <a href="/adventures/">adventures</a>, with more to come.
       </p>
       <p>
-        These days I put most of my spare time into two hobbies: homebrewing with <a href="https://notomorrowbrewing.com" target="_blank" rel="noopener noreferrer">Not Tomorrow Brewing</a>, and
-        building <a href="https://tour-de-friends.fly.dev/" target="_blank" rel="noopener noreferrer">Tour de Friends</a>, an app for tracking group rides with friends.
+        I also put time into two ongoing hobbies: homebrewing at <a href="https://notomorrowbrewing.com" target="_blank" rel="noopener noreferrer">Not Tomorrow Brewing</a>,
+        and building <a href="https://tour-de-friends.fly.dev/" target="_blank" rel="noopener noreferrer">Tour de Friends</a>, an app for tracking group rides with friends.
       </p>
     </div>
   </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,17 +32,17 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       <a class="btn" href="https://www.linkedin.com/in/luke-morrow" target="_blank" rel="noopener noreferrer"
         >LinkedIn <span aria-hidden="true">↗</span></a
       >
+      <a class="btn" href="https://github.com/ltmorro" target="_blank" rel="noopener noreferrer"
+        >GitHub <span aria-hidden="true">↗</span></a
+      >
       <a class="btn" href="https://strava.app.link/R5BN3emEM4b" target="_blank" rel="noopener noreferrer"
         >Strava <span aria-hidden="true">↗</span></a
-      >
-      <a class="btn" href="https://notomorrowbrewing.com" target="_blank" rel="noopener noreferrer"
-        >Not Tomorrow Brewing <span aria-hidden="true">↗</span></a
       >
       <a class="btn" href="https://tour-de-friends.fly.dev/" target="_blank" rel="noopener noreferrer"
         >Tour de Friends <span aria-hidden="true">↗</span></a
       >
-      <a class="btn" href="https://github.com/ltmorro" target="_blank" rel="noopener noreferrer"
-        >GitHub <span aria-hidden="true">↗</span></a
+      <a class="btn" href="https://notomorrowbrewing.com" target="_blank" rel="noopener noreferrer"
+        >Not Tomorrow Brewing <span aria-hidden="true">↗</span></a
       >
     </div>
   </section>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -17,7 +17,7 @@ const items = entries.map((entry) => ({
 
 <ArchiveLayout
   title="Projects"
-  description="Exploring practical applications of my interests."
+  description="An archive of data science and software projects from my time at Clemson."
   basePath="/projects"
   items={items}
 />


### PR DESCRIPTION
Reflects the Spotify backend engineering role, frames the projects
archive as grad-school work, and links out to hobby projects
(Not Tomorrow Brewing, Tour de Friends).